### PR TITLE
[IMP] PO pdf prints Sciencix internal reference, not the vendor produ…

### DIFF
--- a/sciencix_purchase/models/__init__.py
+++ b/sciencix_purchase/models/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
+from . import purchase

--- a/sciencix_purchase/models/purchase.py
+++ b/sciencix_purchase/models/purchase.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+
+class PurchaseOrderLine(models.Model):
+
+    _inherit = 'purchase.order.line'
+
+
+    @api.multi
+    @api.depends('product_id', 'partner_id')
+    def _compute_seller_product_code(self):
+        for line in self:
+            seller_product_code = line.product_id.default_code if line.product_id else ''
+            if line.partner_id and line.product_id:
+                seller = line.product_id._select_seller(
+                    partner_id=line.partner_id,
+                    quantity=line.product_qty,
+                    date=line.order_id.date_order and line.order_id.date_order[:10],
+                    uom_id=line.product_uom)
+                if seller:
+                    seller_product_code = seller.product_code
+            line.seller_product_code = seller_product_code
+
+    
+    seller_product_code = fields.Char(compute='_compute_seller_product_code', string="Seller Product Code")
+    

--- a/sciencix_purchase/report/report_agreement.xml
+++ b/sciencix_purchase/report/report_agreement.xml
@@ -59,7 +59,7 @@
                                     <span t-field="line.order_id.name"/>
                                 </td>
                                 <td>
-                                    <span t-esc="line.product_id.default_code"/>
+                                    <span t-esc="line.seller_product_code"/>
                                 </td>
                                 <td>
                                     <span t-if="line.name" t-esc="line.name.split(']')[-1]"/>

--- a/sciencix_purchase/report/report_purchase.xml
+++ b/sciencix_purchase/report/report_purchase.xml
@@ -98,7 +98,7 @@
             </xpath>
             <xpath expr="//table[1]/tbody/tr/td[1]" position="before">
                 <td>
-                    <span t-esc="line.product_id.default_code"/>
+                    <span t-esc="line.seller_product_code"/>
                 </td>
             </xpath>
             <span t-field="line.name" position="replace">


### PR DESCRIPTION
…ct code

The report is working as asked in the specification:
""
5. Separate Internal Reference from the description and add it to a new column called " Part ID"
Part ID - Internal reference of the product [generaly there will be only one product in the PO, but if there are more than one products, then display all]
"" 

In standard, the internal reference is replaced with vendor product name. If you think that this is an additional request then please change it accordingly and charge extra time.
